### PR TITLE
Updated functions, and Binder capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -41,4 +41,16 @@ storm = basin.get_storm(('Delta',2020))
 storm.get_recon()
 ```
 
+```
+#mycmap = {0:'w',20:'dodgerblue',60:'gold',100:'firebrick',160:'violet'}
+#storm.recon.plot_points(varname='pkwnd',prop={'cmap':mycmap,'levels':(0,160)})
+storm.recon.hdobs.plot_points()
+```
+
+```
+#mycmap = {0:'w',20:'dodgerblue',60:'gold',100:'firebrick',160:'violet'}
+#storm.recon.plot_hovmoller(prop={'cmap':mycmap,'levels':np.arange(0,161,10)})
+storm.recon.hdobs.plot_hovmoller()
+```
+
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sample-scripts
 Sample scripts for Tropycal usage
 
-Click on the Binder button to open the Notebook:
+Click on a Binder button to open a Notebook.  Binder will start a Jupyter Lab starting at the chosen Notebook, but the other labs will also be available during the session.  (You can find them by clicking the folder icon in the grey left nav bar.)
 
 ## v0.3
 - Storm Plotting Tools, with Michael(2018)

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ v0.5
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
 
 AMS Tropical Talk
-- - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
 

--- a/README.md
+++ b/README.md
@@ -26,5 +26,19 @@ Notes:
 #storms = basin.filter_storms(thresh={'dv_min':90,'dt_window':36},doInterp=True)
 storms = basin.filter_storms(thresh={'dv_min':90,'dt_window':36},interpolate_data=True)
 ```
-This Notebook gets pretty close to Binder's limit of 4GB RAM when it is doing the allbasins part, and it is super slow.
+This Notebook gets pretty close to Binder's limit of 4GB RAM, It because of that it gets slow.
+
+
+```
+#storm.plot_gefs_ensembles(forecast = dt(2018,9,7,12), fhr = [84])
+storm.plot_ensembles(forecast = dt(2018,9,7,12), fhr = [84])
+```
+
+This repo does not have the file `delta_recon`, and it didn't recognize `read_path` anyway.
+```
+storm = basin.get_storm(('Delta',2020))
+#storm.get_recon(read_path="delta_recon") #Here we are reading from a saved file to save time
+storm.get_recon()
+```
+
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 V
 
 Notes:
 ```
-#Add "doInterp=True" to interpolate storm data linearly to hourly
+#Change doInterp to interpolate_data
 #storms = basin.filter_storms(thresh={'dv_min':90,'dt_window':36},doInterp=True)
 storms = basin.filter_storms(thresh={'dv_min':90,'dt_window':36},interpolate_data=True)
 ```
+This Notebook gets pretty close to Binder's limit of 4GB RAM when it is doing the allbasins part, and it is super slow.
 

--- a/README.md
+++ b/README.md
@@ -41,24 +41,7 @@ storm = basin.get_storm(('Delta',2020))
 storm.get_recon()
 ```
 
-```
-#mycmap = {0:'w',20:'dodgerblue',60:'gold',100:'firebrick',160:'violet'}
-#storm.recon.plot_points(varname='pkwnd',prop={'cmap':mycmap,'levels':(0,160)})
-storm.recon.hdobs.plot_points()
-```
+Changed rcon.plot with rcon.hdobs.plot
 
-```
-#mycmap = {0:'w',20:'dodgerblue',60:'gold',100:'firebrick',160:'violet'}
-#storm.recon.plot_hovmoller(prop={'cmap':mycmap,'levels':np.arange(0,161,10)})
-storm.recon.hdobs.plot_hovmoller()
-```
-
-```
-#mycmap = {0:'w',20:'dodgerblue',60:'gold',100:'firebrick',160:'violet'}
-#storm.recon.plot_maps(dt(2020,10,6,18),varname=('pkwnd','p_sfc'),
-#                      prop={'cmap':mycmap,'levels':np.arange(0,161,10)},radlim=150,window=4,align='end')
-storm.recon.hdobs.plot_maps()
-```
-
-
+Tornadoes didn't work, but they will work after you pull my change of error_bad_lines to on_bad_lines.
 

--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@ Click on the Binder button to open the Notebook:
 - Storm Plotting Tools, with Michael(2018)
 - Track composite of Katrina(2005) and Ida(2021)
 - Tropical Cyclone Rainfall, with Harvey(2017)
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.3_sample.ipynb)
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=tropycal_v0.3_sample.ipynb)
 
 ## v0.5
 - Plot Ensemble and Model Tracks
 - Recon Mission & Realtime
 - Cross-Basin Storm Support
 - Features Joaquin(2015), Michael(2018), and Cesar-Douglas(1996)
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
 
 **Note:** Realtime Recon will give errors if there are no active missions.  Just click to the next cell.
 
 
 ## Tropycal: A Python Package for Analyzing Tropical Cyclones and More
 AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 Virtual Meeting. Tomer Burg and Sam P. Lillo.
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
 
 **Changes from original**:
 - `plot_gefs_ensembles` to `plot_ensembles`

--- a/README.md
+++ b/README.md
@@ -3,45 +3,32 @@ Sample scripts for Tropycal usage
 
 Click on the Binder button to open the Notebook:
 
-v0.3
+## v0.3
+- Storm Plotting Tools, with Michael(2018)
+- Track composite of Katrina(2005) and Ida(2021)
+- Tropical Cyclone Rainfall, with Harvey(2017)
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.3_sample.ipynb)
 
 ## v0.5
 - Plot Ensemble and Model Tracks
 - Recon Mission & Realtime
 - Cross-Basin Storm Support
-- Feature Joaquin(2015), Michael(2018), and Cesar-Douglas(1996)
+- Features Joaquin(2015), Michael(2018), and Cesar-Douglas(1996)
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
 
-*Note: Realtime Recon did not work when I tested because number of active mission was zero (list index out of range). Maybe add an error check, to check for an empty list.*
+**Note:** Realtime Recon will give errors if there are no active missions.  Just click to the next cell.
 
 
 ## Tropycal: A Python Package for Analyzing Tropical Cyclones and More
 AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 Virtual Meeting. Tomer Burg and Sam P. Lillo.
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
 
-Notes:
-```
-#Change doInterp to interpolate_data
-#storms = basin.filter_storms(thresh={'dv_min':90,'dt_window':36},doInterp=True)
-storms = basin.filter_storms(thresh={'dv_min':90,'dt_window':36},interpolate_data=True)
-```
-This Notebook gets pretty close to Binder's limit of 4GB RAM, It because of that it gets slow.
+**Changes from original**:
+- `plot_gefs_ensembles` to `plot_ensembles`
+- `rcon.plot`s with `rcon.hdobs.plot`s
 
+**Error**:
+- The tornados parts do not work because of deprecated pd.read argument, but I submitted a pull request with the fix.
 
-```
-#storm.plot_gefs_ensembles(forecast = dt(2018,9,7,12), fhr = [84])
-storm.plot_ensembles(forecast = dt(2018,9,7,12), fhr = [84])
-```
-
-This repo does not have the file `delta_recon`, and it didn't recognize `read_path` anyway.
-```
-storm = basin.get_storm(('Delta',2020))
-#storm.get_recon(read_path="delta_recon") #Here we are reading from a saved file to save time
-storm.get_recon()
-```
-
-Changed rcon.plot with rcon.hdobs.plot
-
-Tornadoes didn't work, but they will work after you pull my change of error_bad_lines to on_bad_lines.
-
+**Warning**:
+- This last Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  It will be better on your local computer. 

--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ Click on a Binder button to open a Notebook.  Binder will start a Jupyter Lab st
 
 ## Tropycal: A Python Package for Analyzing Tropical Cyclones and More
 AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 Virtual Meeting. Tomer Burg and Sam P. Lillo.
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisalenorelowe/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
 
 ## New in v0.3
 - Storm Plotting Tools, with Michael(2018)
 - Track composite of Katrina(2005) and Ida(2021)
 - Tropical Cyclone Rainfall, with Harvey(2017)
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=tropycal_v0.3_sample.ipynb)
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisalenorelowe/sample-scripts/HEAD?labpath=tropycal_v0.3_sample.ipynb)
 
 ## New in v0.5
 - Plot Ensemble and Model Tracks
 - Recon Mission & Realtime
 - Cross-Basin Storm Support
 - Features Joaquin(2015), Michael(2018), and Cesar-Douglas(1996)
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisalenorelowe/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
 
 ## Notes
 - In v0.5, Realtime Recon will give errors if there are no active missions.  Just click to the next cell.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 V
 - Features Joaquin(2015), Michael(2018), and Cesar-Douglas(1996)
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
 
-**Notes:** 
+## Notes
 - In v0.5, Realtime Recon will give errors if there are no active missions.  Just click to the next cell.
 - The tornados parts do not work as of July 20, 2023 because of deprecated pd.read argument.  The fix is coming soon.
 - The **Tropycal, AMS** Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  We recommend using Jupyter Notebook locally by using miniconda to create an environment for tropycal+Notebook.  A YAML file for creating the environment is included in this repo: ***env_tropycal.yml***.

--- a/README.md
+++ b/README.md
@@ -3,32 +3,24 @@ Sample scripts for Tropycal usage
 
 Click on a Binder button to open a Notebook.  Binder will start a Jupyter Lab starting at the chosen Notebook, but the other labs will also be available during the session.  (You can find them by clicking the folder icon in the grey left nav bar.)
 
-## v0.3
+## Tropycal: A Python Package for Analyzing Tropical Cyclones and More
+AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 Virtual Meeting. Tomer Burg and Sam P. Lillo.
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
+
+## New in v0.3
 - Storm Plotting Tools, with Michael(2018)
 - Track composite of Katrina(2005) and Ida(2021)
 - Tropical Cyclone Rainfall, with Harvey(2017)
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=tropycal_v0.3_sample.ipynb)
 
-## v0.5
+## New in v0.5
 - Plot Ensemble and Model Tracks
 - Recon Mission & Realtime
 - Cross-Basin Storm Support
 - Features Joaquin(2015), Michael(2018), and Cesar-Douglas(1996)
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
 
-**Note:** Realtime Recon will give errors if there are no active missions.  Just click to the next cell.
-
-
-## Tropycal: A Python Package for Analyzing Tropical Cyclones and More
-AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 Virtual Meeting. Tomer Burg and Sam P. Lillo.
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tropycal/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
-
-**Changes from original**:
-- `plot_gefs_ensembles` to `plot_ensembles`
-- `rcon.plot`s with `rcon.hdobs.plot`s
-
-**Error**:
-- The tornados parts do not work because of deprecated pd.read argument, but I submitted a pull request with the fix.
-
-**Warning**:
-- This last Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  We recommend using Jupyter Notebook locally by using miniconda to create an environment for tropycal+Notebook.  A YAML file for creating the environment is included in this repo: ***env_tropycal.yml***.
+**Notes:** 
+- In v0.5, Realtime Recon will give errors if there are no active missions.  Just click to the next cell.
+- The tornados parts do not work as of July 20, 2023 because of deprecated pd.read argument.  The fix is coming soon.
+- The **Tropycal, AMS** Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  We recommend using Jupyter Notebook locally by using miniconda to create an environment for tropycal+Notebook.  A YAML file for creating the environment is included in this repo: ***env_tropycal.yml***.

--- a/README.md
+++ b/README.md
@@ -22,5 +22,4 @@ AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 V
 
 ## Notes
 - In v0.5, Realtime Recon will give errors if there are no active missions.  Just click to the next cell.
-- The tornados parts do not work as of July 20, 2023 because of deprecated pd.read argument.  The fix is coming soon.
 - The **Tropycal, AMS** Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  We recommend using Jupyter Notebook locally by using miniconda to create an environment for tropycal+Notebook.  A YAML file for creating the environment is included in this repo: ***env_tropycal.yml***.

--- a/README.md
+++ b/README.md
@@ -53,4 +53,12 @@ storm.recon.hdobs.plot_points()
 storm.recon.hdobs.plot_hovmoller()
 ```
 
+```
+#mycmap = {0:'w',20:'dodgerblue',60:'gold',100:'firebrick',160:'violet'}
+#storm.recon.plot_maps(dt(2020,10,6,18),varname=('pkwnd','p_sfc'),
+#                      prop={'cmap':mycmap,'levels':np.arange(0,161,10)},radlim=150,window=4,align='end')
+storm.recon.hdobs.plot_maps()
+```
+
+
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,24 @@ Click on the Binder button to open the Notebook:
 v0.3
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.3_sample.ipynb)
 
-v0.5
+## v0.5
+- Plot Ensemble and Model Tracks
+- Recon Mission & Realtime
+- Cross-Basin Storm Support
+- Feature Joaquin(2015), Michael(2018), and Cesar-Douglas(1996)
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
 
-AMS Tropical Talk
+*Note: Realtime Recon did not work when I tested because number of active mission was zero (list index out of range). Maybe add an error check, to check for an empty list.*
+
+
+## Tropycal: A Python Package for Analyzing Tropical Cyclones and More
+AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 Virtual Meeting. Tomer Burg and Sam P. Lillo.
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
+
+Notes:
+```
+#Add "doInterp=True" to interpolate storm data linearly to hourly
+#storms = basin.filter_storms(thresh={'dv_min':90,'dt_window':36},doInterp=True)
+storms = basin.filter_storms(thresh={'dv_min':90,'dt_window':36},interpolate_data=True)
+```
 

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 V
 - The tornados parts do not work because of deprecated pd.read argument, but I submitted a pull request with the fix.
 
 **Warning**:
-- This last Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  It will be better on your local computer. 
+- This last Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  We recommend using Jupyter Notebook locally by using miniconda to create an environment for tropycal+Notebook.  A YAML file for creating the environment is included in this repo: ***env_tropycal.yml***.

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ AMS 34th Conference on Hurricanes and Tropical Meteorology, 10 – 14 May 2021 V
 
 ## Notes
 - In v0.5, Realtime Recon will give errors if there are no active missions.  Just click to the next cell.
-- The **Tropycal, AMS** Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  We recommend using Jupyter Notebook locally by using miniconda to create an environment for tropycal+Notebook.  A YAML file for creating the environment is included in this repo: ***env_tropycal.yml***.
+- The **Tropycal, AMS** Notebook gets pretty close to Binder's limit of 4GB RAM, so it gets very slow.  (And if Binder assigns you a VM with 2GB, it will crash.)  We recommend using Jupyter Notebook locally by using miniconda to create an environment for tropycal+Notebook.  A YAML file for creating the environment is included in this repo: ***env_tropycal.yml***.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # sample-scripts
 Sample scripts for Tropycal usage
+
+Click on the Binder button to open the Notebook:
+
+v0.3
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.3_sample.ipynb)
+
+v0.5
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=tropycal_v0.5_sample.ipynb)
+
+AMS Tropical Talk
+- - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lisaleorelowe/sample-scripts/HEAD?labpath=AMS_Tropical_Talk.ipynb)
+

--- a/env_tropycal.yml
+++ b/env_tropycal.yml
@@ -1,0 +1,14 @@
+name: tropycal
+channels:
+  - conda-forge
+dependencies:
+  - matplotlib >= 2.2.2
+  - numpy >= 1.14.3
+  - scipy >= 1.1.0
+  - pandas >= 0.23.0
+  - xarray >= 0.10.7
+  - networkx >= 2.0.0
+  - pyshp >= 2.1
+  - cartopy >= 0.17.0
+  - tropycal
+  - notebook 

--- a/env_tropycal.yml
+++ b/env_tropycal.yml
@@ -5,7 +5,7 @@ dependencies:
   - matplotlib >= 2.2.2
   - numpy >= 1.14.3
   - scipy >= 1.1.0
-  - pandas >= 0.23.0
+  - pandas <= 1.5.2
   - xarray >= 0.10.7
   - networkx >= 2.0.0
   - pyshp >= 2.1

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,3 @@ dependencies:
   - pyshp >= 2.1
   - cartopy >= 0.17.0
   - tropycal
-  - wget

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - matplotlib >= 2.2.2
   - numpy >= 1.14.3
   - scipy >= 1.1.0
-  - pandas >= 0.23.0
+  - pandas <= 1.5.2
   - xarray >= 0.10.7
   - networkx >= 2.0.0
   - pyshp >= 2.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: tropycal
+channels:
+  - conda-forge
+dependencies:
+  - matplotlib >= 2.2.2
+  - numpy >= 1.14.3
+  - scipy >= 1.1.0
+  - pandas >= 0.23.0
+  - xarray >= 0.10.7
+  - networkx >= 2.0.0
+  - pyshp >= 2.1
+  - cartopy >= 0.17.0
+  - tropycal
+  - wget


### PR DESCRIPTION
In AMS talk, changed deprecated functions:
- `doInterp=True` to `interpolate_data=True`
- `plot_gefs_ensembles` to `storm.plot_ensembles`
- `recon.plot*` to `recon.hdobs.plot*`  (not sure if that's exactly the same, but they work)

Added environment YAML files:
- environment.yml: that's what Binder looks for to build the VM
- env_tropycal.yml: for making a conda environment with Tropycal and Jupyter Notebook

Added a TOC and Binder buttons to the README.

The tornado functions will not work with the current Tropycal, unless maybe an older version of pandas is specified.  I used the dependencies listed on the README, which has `pandas >= 0.23.0`.  There were just two very minor changes to fix it, so I did that and did a pull request.

In the AMS talk, I modified everything above the Tornado part, so someone clicking on just the ipynb image can see what the plots are supposed to look like.  (That means I couldn't check if the Tornado functions are deprecated.)


